### PR TITLE
fix: 벽돌 미니게임 공이 수직/수평 궤도에 갇히는 버그 수정

### DIFF
--- a/Assets/Scripts/MiniGame/BrickMiniGame/BallController.cs
+++ b/Assets/Scripts/MiniGame/BrickMiniGame/BallController.cs
@@ -16,6 +16,9 @@ public class BallController : MonoBehaviour
     [SerializeField]
     private float paddleInfluence = 0.05f;
 
+    [SerializeField]
+    private float maxBounceAngle = 60f;
+
     [Header("오디오 매니저")]
     [SerializeField]
     private AudioManager audioManager;
@@ -62,8 +65,8 @@ public class BallController : MonoBehaviour
         {
             isGameStarted = true;
             rb.gravityScale = 0f;
-
             rb.linearVelocity = new Vector2(Random.Range(-2f, 2f), constantSpeed);
+            return;
         }
 
         if (collision.gameObject.CompareTag("Brick"))
@@ -71,9 +74,20 @@ public class BallController : MonoBehaviour
             Destroy(collision.gameObject);
             audioManager.PlaySfx(5);
         }
+
         if (collision.gameObject.CompareTag("Paddle"))
         {
             audioManager.PlaySfx(6);
+
+            float paddleHalfWidth = collision.collider.bounds.extents.x;
+            float normalizedHit = Mathf.Clamp(
+                (transform.position.x - collision.transform.position.x) / paddleHalfWidth,
+                -1f,
+                1f
+            );
+            float angleRad = normalizedHit * maxBounceAngle * Mathf.Deg2Rad;
+            rb.linearVelocity =
+                new Vector2(Mathf.Sin(angleRad), Mathf.Cos(angleRad)) * constantSpeed;
         }
     }
 


### PR DESCRIPTION
## Summary

- 패들 충돌 시 Unity 기본 거울 반사 대신 **Breakout 스타일 반사** 적용 — 패들의 hit 위치(`-1..+1`)를 기반으로 반사 각도 결정
- 첫 발사 분기에 `return` 추가해 발사 직후 랜덤 각도 보존
- `maxBounceAngle = 60f` 필드 추가 (인스펙터에서 튜닝 가능)
- 기존 `minVelocity` safety net 유지 — 벽·벽돌 반사로 인한 수평 갇힘 방어

Closes #56

## Test plan

- [ ] 발사 후 패들을 중앙에 고정 → 공이 수직 궤도 진입 → 패들을 좌/우로 움직이면 새 각도로 반사되는지
- [ ] 패들 좌/우 끝에서 받으면 수직 기준 ±60° 각도로 튀는지
- [ ] 패들 정중앙에서 받으면 수직(0°)으로 튀는지
- [ ] 어떤 hit 위치에서도 공이 항상 위쪽(`vy > 0`)으로 반사되는지
- [ ] 벽·벽돌 충돌은 기존 자연 물리 반사 그대로인지
- [ ] 모든 벽돌 파괴 후 동의 버튼 클릭 → 미니게임 성공 처리되는지
- [ ] 공이 데드존 진입 시 GameOver 정상 처리되는지

🤖 Generated with [Claude Code](https://claude.com/claude-code)