### PR TITLE
fix: 벽돌 미니게임 공이 수직/수평 궤도에 갇히는 버그 수정

### DIFF
--- a/Assets/Scripts/MiniGame/BrickMiniGame/BallController.cs
+++ b/Assets/Scripts/MiniGame/BrickMiniGame/BallController.cs
@@ -85,9 +85,13 @@ public class BallController : MonoBehaviour
                 -1f,
                 1f
             );
-            float angleRad = normalizedHit * maxBounceAngle * Mathf.Deg2Rad;
-            rb.linearVelocity =
-                new Vector2(Mathf.Sin(angleRad), Mathf.Cos(angleRad)) * constantSpeed;
+
+            if (Mathf.Abs(normalizedHit) > 0.9f)
+            {
+                float angleRad = normalizedHit * maxBounceAngle * Mathf.Deg2Rad;
+                rb.linearVelocity =
+                    new Vector2(Mathf.Sin(angleRad), Mathf.Cos(angleRad)) * constantSpeed;
+            }
         }
     }
 

--- a/Assets/Scripts/MiniGame/BrickMiniGame/BallController.cs
+++ b/Assets/Scripts/MiniGame/BrickMiniGame/BallController.cs
@@ -16,6 +16,9 @@ public class BallController : MonoBehaviour
     [SerializeField]
     private float paddleInfluence = 0.05f;
 
+    [SerializeField]
+    private float maxBounceAngle = 60f;
+
     [Header("오디오 매니저")]
     [SerializeField]
     private AudioManager audioManager;
@@ -62,8 +65,8 @@ public class BallController : MonoBehaviour
         {
             isGameStarted = true;
             rb.gravityScale = 0f;
-
             rb.linearVelocity = new Vector2(Random.Range(-2f, 2f), constantSpeed);
+            return;
         }
 
         if (collision.gameObject.CompareTag("Brick"))
@@ -71,9 +74,20 @@ public class BallController : MonoBehaviour
             Destroy(collision.gameObject);
             audioManager.PlaySfx(5);
         }
+
         if (collision.gameObject.CompareTag("Paddle"))
         {
             audioManager.PlaySfx(6);
+
+            float paddleHalfWidth = collision.collider.bounds.extents.x;
+            float normalizedHit = Mathf.Clamp(
+                (transform.position.x - collision.transform.position.x) / paddleHalfWidth,
+                -1f,
+                1f
+            );
+            float angleRad = normalizedHit * maxBounceAngle * Mathf.Deg2Rad;
+            rb.linearVelocity =
+                new Vector2(Mathf.Sin(angleRad), Mathf.Cos(angleRad)) * constantSpeed;
         }
     }
 


### PR DESCRIPTION
## Summary

- 패들 좌우 끝 10% 구간(`|normalizedHit| > 0.9`)에서만 Breakout 스타일 각도 반사 적용
- 나머지 중앙 80% 구간은 기존 Unity 거울 반사 유지
- `maxBounceAngle = 60f` 필드로 끝 구간 최대 반사 각도 인스펙터에서 조정 가능
- 기존 `minVelocity` safety net 유지 — 벽·벽돌 반사로 인한 수평 갇힘 방어

Closes #56

## Test plan

- [ ] 패들 중앙(80% 구간)에서 받으면 기존 거울 반사 그대로인지
- [ ] 패들 좌/우 끝 10% 구간에서 받으면 각도 반사가 적용되는지
- [ ] 수직 갇힘 상황에서 패들을 끝으로 이동해 각도를 바꿀 수 있는지
- [ ] 공이 항상 위쪽(`vy > 0`)으로 반사되는지
- [ ] 모든 벽돌 파괴 후 동의 버튼 클릭 → 미니게임 성공 처리되는지
- [ ] 공이 데드존 진입 시 GameOver 정상 처리되는지

🤖 Generated with [Claude Code](https://claude.com/claude-code)